### PR TITLE
Add Capture Device Authorization

### DIFF
--- a/Sources/Goggles/Camera.swift
+++ b/Sources/Goggles/Camera.swift
@@ -4,7 +4,6 @@
 // Copyright © 2023 Gaetano Matonti. All rights reserved.
 //
 
-#if canImport(SwiftUI)
 import AVFoundation
 import OSLog
 import SwiftUI
@@ -166,4 +165,3 @@ extension Camera: AVCaptureVideoDataOutputSampleBufferDelegate {
     }
   }
 }
-#endif

--- a/Sources/Goggles/CameraView.swift
+++ b/Sources/Goggles/CameraView.swift
@@ -4,7 +4,6 @@
 // Copyright © 2023 Gaetano Matonti. All rights reserved.
 //
 
-#if canImport(SwiftUI)
 import SwiftUI
 
 /// A view that displays the frames of a video stream.
@@ -58,4 +57,3 @@ public struct CameraView: View {
 #Preview {
   CameraView()
 }
-#endif

--- a/Sources/Goggles/CaptureAuthorization.swift
+++ b/Sources/Goggles/CaptureAuthorization.swift
@@ -1,0 +1,95 @@
+//
+// Goggles
+//
+// Copyright © 2023 Gaetano Matonti. All rights reserved.
+//
+
+import AVFoundation
+
+/// An object that manages authorization requests to capture devices.
+public struct CaptureAuthorization {
+  
+  // MARK: - Stored Properties
+  
+  /// Requests the authorization status for the specified `AVMediaType`.
+  public var requestAuthorization: (AVMediaType) async -> Bool
+  
+  /// The authorization status for the specified `AVMediaType`.
+  public var authorizationStatus: (AVMediaType) -> AVAuthorizationStatus
+  
+  /// Requests the authorization status for the `.video` media type.
+  ///
+  /// Use this function to request the authorization status for the `Camera` object.
+  public let requestCameraAuthorization: () async -> Bool
+  
+  /// The authorization status for the `.video` media type.
+  ///
+  /// Use this function to access the authorization status for the `Camera` object.
+  public var cameraAuthorizationStatus: AVAuthorizationStatus {
+    authorizationStatus(.video)
+  }
+  
+  // MARK: - Init
+  
+  /// Creates an instance of the `CaptureAuthorization` object.
+  /// - Parameters:
+  ///   - requestAuthorization: The function that requests the authorization status for the specified `AVMediaType`.
+  ///   - authorizationStatus: The function that returns the authorization status for the specified `AVMediaType`.
+  public init(
+    authorizationStatus: @escaping (AVMediaType) -> AVAuthorizationStatus,
+    requestAuthorization: @escaping (AVMediaType) async -> Bool
+  ) {
+    self.authorizationStatus = authorizationStatus
+    self.requestAuthorization = requestAuthorization
+    self.requestCameraAuthorization = {
+      await requestAuthorization(.video)
+    }
+  }
+}
+
+public extension CaptureAuthorization {
+  /// A live instance of the `CaptureAuthorization` object.
+  ///
+  /// This object interacts with the `AVFoundation` APIs to determine and request authorization to capture devices.
+  static let live = CaptureAuthorization { mediaType in
+    AVCaptureDevice.authorizationStatus(for: mediaType)
+  } requestAuthorization: { mediaType in
+    await AVCaptureDevice.requestAccess(for: mediaType)
+  }
+  
+  /// A mock instance of the `CaptureAuthorization` object.
+  ///
+  /// This object returns a `.authorized` status and authorization request always succeeds.
+  static let mockWithAuthorizedStatus = CaptureAuthorization { _ in
+      .authorized
+  } requestAuthorization: { _ in
+    true
+  }
+  
+  /// A mock instance of the `CaptureAuthorization` object.
+  ///
+  /// This object returns a `.restricted` status and authorization request always fails.
+  static let mockWithRestrictedStatus = CaptureAuthorization { _ in
+      .restricted
+  } requestAuthorization: { _ in
+    false
+  }
+  
+  /// A mock instance of the `CaptureAuthorization` object.
+  ///
+  /// This object returns a `.notDetermined` status and authorization request always fails.
+  static let mockWithNotDeterminedStatus = CaptureAuthorization { _ in
+      .notDetermined
+  } requestAuthorization: { _ in
+    false
+  }
+  
+  /// A mock instance of the `CaptureAuthorization` object.
+  ///
+  /// This object returns a `.denied` status and authorization request always fails.
+  static let mockWithDeniedStatus = CaptureAuthorization { _ in
+      .denied
+  } requestAuthorization: { _ in
+    false
+  }
+}

--- a/Sources/Goggles/CaptureAuthorization.swift
+++ b/Sources/Goggles/CaptureAuthorization.swift
@@ -61,7 +61,7 @@ public extension CaptureAuthorization {
   ///
   /// This object returns a `.authorized` status and authorization request always succeeds.
   static let mockWithAuthorizedStatus = CaptureAuthorization { _ in
-      .authorized
+    .authorized
   } requestAuthorization: { _ in
     true
   }
@@ -70,7 +70,7 @@ public extension CaptureAuthorization {
   ///
   /// This object returns a `.restricted` status and authorization request always fails.
   static let mockWithRestrictedStatus = CaptureAuthorization { _ in
-      .restricted
+    .restricted
   } requestAuthorization: { _ in
     false
   }
@@ -79,7 +79,7 @@ public extension CaptureAuthorization {
   ///
   /// This object returns a `.notDetermined` status and authorization request always fails.
   static let mockWithNotDeterminedStatus = CaptureAuthorization { _ in
-      .notDetermined
+    .notDetermined
   } requestAuthorization: { _ in
     false
   }
@@ -88,7 +88,7 @@ public extension CaptureAuthorization {
   ///
   /// This object returns a `.denied` status and authorization request always fails.
   static let mockWithDeniedStatus = CaptureAuthorization { _ in
-      .denied
+    .denied
   } requestAuthorization: { _ in
     false
   }


### PR DESCRIPTION
This PR adds the `CaptureAuthorization` object to manage authorization requests and status access.

### Changes
- Added the `CaptureAuthorization` object.
- Added a `live` implementation of the `CaptureAuthorization` object that interacts with the `AVFoundation` APIs.
- Added several mock implementations of the `CaptureAuthorization` object that return different statuses and authorization request results.